### PR TITLE
Fix issue with npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,8 @@ ARG GID=1000
 RUN usermod  --uid $UID $UNAME
 RUN groupmod --gid $GID $UGROUP
 
+RUN mkdir -p /var/www/.npm && chown -R $UID:$GID /var/www/.npm
+
 USER www-data
 
 WORKDIR /var/www/html


### PR DESCRIPTION
    npm ERR! code EACCES
    npm ERR! syscall mkdir
    npm ERR! path /var/www/.npm
    npm ERR! errno -13
    npm ERR!
    npm ERR! Your cache folder contains root-owned files, due to a bug in
    npm ERR! previous versions of npm which has since been addressed.
    npm ERR!
    npm ERR! To permanently fix this problem, please run:
    npm ERR!   sudo chown -R 1000:1000 "/var/www/.npm"

    npm ERR! Log files were not written due to an error writing to the directory: /var/www/.npm/_logs
    npm ERR! You can rerun the command with `--loglevel=verbose` to see the logs in your terminal