### PR TITLE
Install Kepubify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM php:8.2-apache-bookworm
 
 RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 
-ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV COMPOSER_HOME /home/.composer
+ENV COMPOSER_ALLOW_SUPERUSER=1
+ENV COMPOSER_HOME=/home/.composer
 RUN mkdir -p /home/.composer
 RUN printf "deb http://http.us.debian.org/debian stable main contrib non-free" > /etc/apt/sources.list.d/nonfree.list
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,16 @@ RUN install-php-extensions \
     imagick \
     @composer
 
+# Install kepubify (from https://github.com/linuxserver/docker-calibre-web/blob/master/Dockerfile)
+RUN \
+    if [ -z ${KEPUBIFY_RELEASE+x} ]; then \
+    KEPUBIFY_RELEASE=$(curl -sX GET "https://api.github.com/repos/pgaskin/kepubify/releases/latest" \
+    | awk '/tag_name/{print $4;exit}' FS='[""]'); \
+  fi && \
+  curl -o \
+    /usr/bin/kepubify -L \
+    https://github.com/pgaskin/kepubify/releases/download/${KEPUBIFY_RELEASE}/kepubify-linux-64bit && \
+    chmod +x /usr/bin/kepubify
 
 RUN a2enmod rewrite
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,35 @@
 FROM php:8.2-apache-bookworm
 
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /home/.composer
 RUN mkdir -p /home/.composer
 RUN printf "deb http://http.us.debian.org/debian stable main contrib non-free" > /etc/apt/sources.list.d/nonfree.list
-RUN  apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    # Tools
-    vim git curl cron wget zip unzip \
-    # other
+
+# npm is included in nodejs, see https://askubuntu.com/a/1432138
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     apt-transport-https \
-    dma  \
-    p7zip-full \
     build-essential \
     ca-certificates \
+    cron \
+    curl \
+    dma  \
+    ghostscript \
+    git \
     mariadb-client \
+    nodejs \
     openssl \
+    p7zip-full \
+    sudo \
     supervisor \
     tesseract-ocr \
-    nodejs \
-    ghostscript \
     unrar \
-    npm \
-    sudo && rm -rf /var/lib/apt/lists/*
+    unzip \
+    vim \
+    wget  \
+    zip \
+    && rm -rf /var/lib/apt/lists/*
 
 # auto install dependencies and remove libs after installing ext: https://github.com/mlocati/docker-php-extension-installer
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
@@ -42,7 +47,6 @@ RUN install-php-extensions \
     @composer
 
 
-RUN apt-get purge -y --auto-remove
 RUN a2enmod rewrite
 
 COPY docker/001-biblioteca.conf /etc/apache2/sites-enabled/001-biblioteca.conf


### PR DESCRIPTION
# Convert EPUBs to Kobo EPUBs.

Kepubify is the fastest tool for converting EPUBs to Kobo's enhanced KEPUB format for use on Kobo eReaders.
See <https://pgaskin.net/kepubify/>

Please merge https://github.com/biblioverse/biblioteca-docker/pull/2 at first