### PR TITLE
add p7zip-rar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     nodejs \
     openssl \
     p7zip-full \
+    p7zip-rar \ 
     sudo \
     supervisor \
     unrar \


### PR DESCRIPTION
Apprently 7zip by default can't extract from `.rar` archives.

The `p7zip-rar` package must be explicitly installed: https://askubuntu.com/a/348175

Tested within biblioteca in dev mode and it does indeed help for .cbr files

This is related to the scanning issues I raised; https://github.com/biblioverse/biblioteca/issues/317