### PR TITLE
Update Imagick's policy to avoid crashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ RUN install-php-extensions \
     imagick \
     @composer
 
+# Increase available space to avoid imagick crashes https://github.com/ImageMagick/ImageMagick/issues/396
+RUN sed -i '/<policy domain="resource" name="disk"/c\  <policy domain="resource" name="disk" value="8GiB"/>/' /etc/ImageMagick-6/policy.xml
+
 # Install kepubify (from https://github.com/linuxserver/docker-calibre-web/blob/master/Dockerfile)
 COPY docker/get_kepubify_url.sh /usr/bin/get_kepubify_url.sh
 RUN chmod +x /usr/bin/get_kepubify_url.sh ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,6 @@ RUN install-php-extensions \
     imagick \
     @composer
 
-# Increase available space to avoid imagick crashes https://github.com/ImageMagick/ImageMagick/issues/396
-RUN sed -i '/<policy domain="resource" name="disk"/c\  <policy domain="resource" name="disk" value="8GiB"/>/' /etc/ImageMagick-6/policy.xml
-
 # Install kepubify (from https://github.com/linuxserver/docker-calibre-web/blob/master/Dockerfile)
 COPY docker/get_kepubify_url.sh /usr/bin/get_kepubify_url.sh
 RUN chmod +x /usr/bin/get_kepubify_url.sh ; \

--- a/docker/policy.xml
+++ b/docker/policy.xml
@@ -63,7 +63,7 @@
   <policy domain="resource" name="height" value="16KP"/>
   <!-- <policy domain="resource" name="list-length" value="128"/> -->
   <policy domain="resource" name="area" value="128MP"/>
-  <policy domain="resource" name="disk" value="1GiB"/>
+  <policy domain="resource" name="disk" value="8GiB"/>
   <!-- <policy domain="resource" name="file" value="768"/> -->
   <!-- <policy domain="resource" name="thread" value="4"/> -->
   <!-- <policy domain="resource" name="throttle" value="0"/> -->


### PR DESCRIPTION
Extracting the cover from PDFs sometimes crashes with 

```
Error, page_0 is not an image: cache resources exhausted `/tmp/magick-MEUnRhIPjodKoNbmiZiE_XiYy0Tn9dQV1' @ error/cache.c/OpenPixelCache/4095
```

This was swallowed by the php-archive library.
Once increased the error disappears

This is related to the scanning issues I raised; https://github.com/biblioverse/biblioteca/issues/317