### PR TITLE
Improve image build speed and size

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,9 +25,6 @@ jobs:
   # Get the repository's code
       - name: Checkout
         uses: actions/checkout@v4
-      # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04-arm
     steps:
   # Get the repository's code
       - name: Checkout

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
   # Get the repository's code
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-apache-bookworm
+FROM php:8.3.15-apache-bookworm
 
 RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     zip \
     && chmod +x /usr/bin/install.sh \
     && /usr/bin/install.sh \
-    opcache \
     intl \
+    opcache \
     pdo_mysql \
     zip \
     bcmath \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,30 @@ ENV COMPOSER_HOME=/home/.composer
 RUN mkdir -p /home/.composer
 RUN printf "deb http://http.us.debian.org/debian stable main contrib non-free" > /etc/apt/sources.list.d/nonfree.list
 
+# npm is included in nodejs, see https://askubuntu.com/a/1432138
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
+    apt-transport-https \
+    build-essential \
+    ca-certificates \
+    cron \
+    curl \
+    dma  \
+    ghostscript \
+    git \
+    mariadb-client \
+    nodejs \
+    openssl \
+    p7zip-full \
+    p7zip-rar \ 
+    sudo \
+    supervisor \
+    unrar \
+    unzip \
+    vim \
+    wget  \
+    zip \
+    && rm -rf /var/lib/apt/lists/*
+
 # auto install dependencies and remove libs after installing ext: https://github.com/mlocati/docker-php-extension-installer
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,16 @@ COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr
 
 COPY docker/install.sh /usr/bin/install.sh
 
-RUN chmod +x /usr/bin/install.sh && /usr/bin/install.sh
+RUN chmod +x /usr/bin/install.sh && /usr/bin/install.sh \
+    opcache \
+    intl \
+    pdo_mysql \
+    zip \
+    bcmath \
+    exif \
+    gd \
+    imagick \
+    @composer
 
 # Install kepubify (from https://github.com/linuxserver/docker-calibre-web/blob/master/Dockerfile)
 COPY docker/get_kepubify_url.sh /usr/bin/get_kepubify_url.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     && chmod +x /usr/bin/install.sh \
     && /usr/bin/install.sh \
     intl \
+    gd \
     opcache \
     pdo_mysql \
     zip \
     bcmath \
     exif \
-    gd \
     imagick \
     @composer \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ ENV COMPOSER_HOME=/home/.composer
 RUN mkdir -p /home/.composer
 RUN printf "deb http://http.us.debian.org/debian stable main contrib non-free" > /etc/apt/sources.list.d/nonfree.list
 
+# auto install dependencies and remove libs after installing ext: https://github.com/mlocati/docker-php-extension-installer
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+
+COPY docker/install.sh /usr/bin/install.sh
+
 # npm is included in nodejs, see https://askubuntu.com/a/1432138
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     apt-transport-https \
@@ -29,14 +34,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     vim \
     wget  \
     zip \
-    && rm -rf /var/lib/apt/lists/*
-
-# auto install dependencies and remove libs after installing ext: https://github.com/mlocati/docker-php-extension-installer
-COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
-
-COPY docker/install.sh /usr/bin/install.sh
-
-RUN chmod +x /usr/bin/install.sh && /usr/bin/install.sh \
+    && chmod +x /usr/bin/install.sh \
+    && /usr/bin/install.sh \
     opcache \
     intl \
     pdo_mysql \
@@ -45,7 +44,8 @@ RUN chmod +x /usr/bin/install.sh && /usr/bin/install.sh \
     exif \
     gd \
     imagick \
-    @composer
+    @composer \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install kepubify (from https://github.com/linuxserver/docker-calibre-web/blob/master/Dockerfile)
 COPY docker/get_kepubify_url.sh /usr/bin/get_kepubify_url.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,24 +15,15 @@ COPY docker/install.sh /usr/bin/install.sh
 # npm is included in nodejs, see https://askubuntu.com/a/1432138
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     apt-transport-https \
-    build-essential \
     ca-certificates \
-    cron \
-    curl \
     dma  \
     ghostscript \
-    git \
     mariadb-client \
-    nodejs \
     openssl \
     p7zip-full \
     p7zip-rar \ 
-    sudo \
-    supervisor \
     unrar \
     unzip \
-    vim \
-    wget  \
     zip \
     && chmod +x /usr/bin/install.sh \
     && /usr/bin/install.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,22 +10,9 @@ RUN printf "deb http://http.us.debian.org/debian stable main contrib non-free" >
 # auto install dependencies and remove libs after installing ext: https://github.com/mlocati/docker-php-extension-installer
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 
-ENV PACKAGES="apt-transport-https ca-certificates cron dma ghostscript mariadb-client nodejs openssl supervisor"
-ENV PACKAGES_DEV="curl git sudo vim wget"
-ENV PACKAGES_COMPRESS="p7zip-full p7zip-rar unrar unzip zip"
-ENV PACKAGES_PHP="libicu72"
-ENV PACKAGES_PHP_VOLATILE="libicu-dev"
+COPY docker/install.sh /usr/bin/install.sh
 
-ENV PHP_PACKAGES="opcache pdo_mysql zip bcmath exif gd imagick @composer"
-
-# npm is included in nodejs, see https://askubuntu.com/a/1432138
-RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-    && apt-get install -y ${PACKAGES} ${PACKAGES_DEV} ${PACKAGES_COMPRESS} ${PACKAGES_PHP} ${PACKAGES_PHP_VOLATILE} \
-    && install-php-extensions ${PHP_PACKAGES} \
-    && docker-php-ext-install intl \
-    && docker-php-ext-enable intl \
-    && apt-get purge ${PACKAGES_PHP_VOLATILE} -y \
-    && rm -rf /var/lib/apt/lists/*
+RUN chmod +x /usr/bin/install.sh && /usr/bin/install.sh
 
 # Install kepubify (from https://github.com/linuxserver/docker-calibre-web/blob/master/Dockerfile)
 COPY docker/get_kepubify_url.sh /usr/bin/get_kepubify_url.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr
 
 RUN install-php-extensions \
     opcache \
-    intl \
     pdo_mysql \
     zip \
     bcmath \

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/bash
+
+# npm is included in nodejs, see https://askubuntu.com/a/1432138
+PACKAGES="apt-transport-https ca-certificates cron dma ghostscript mariadb-client nodejs openssl supervisor"
+PACKAGES_DEV="curl git sudo vim wget"
+PACKAGES_COMPRESS="p7zip-full p7zip-rar unrar unzip zip"
+
+install_php_extension() {
+    local extension=$1
+    local output
+
+    echo "Installing PHP extension $extension"
+
+    output=$(docker-php-ext-install "$extension" 2>&1)
+    if [ $? -ne 0 ]; then
+        echo "Failed to install PHP extension $extension:"
+        echo "$output"
+        echo "Failed to install $extension"
+        exit
+    fi
+
+    echo "[ OK ] PHP extension $extension installed"
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+
+apt-get install -y ${PACKAGES} ${PACKAGES_DEV} ${PACKAGES_COMPRESS} ${PACKAGES_PHP} ${PACKAGES_PHP_VOLATILE}
+
+install_php_extension opcache
+install_php_extension pdo_mysql
+install_php_extension zip
+install_php_extension bcmath
+install_php_extension exif
+install_php_extension gd
+install_php_extension intl
+install_php_extension @composer
+
+rm -rf /var/lib/apt/lists/*

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,32 +1,21 @@
 #!/usr/bin/bash
 
-# npm is included in nodejs, see https://askubuntu.com/a/1432138
-PACKAGES="apt-transport-https ca-certificates cron dma ghostscript mariadb-client nodejs openssl supervisor"
-PACKAGES_DEV="curl git sudo vim wget"
-PACKAGES_COMPRESS="p7zip-full p7zip-rar unrar unzip zip"
-
 install_php_extension() {
     local extension=$1
     local output
 
-    echo "Installing PHP extension $extension"
+    echo "[$(date +"%H:%M:%S")][$extension] Installing PHP extension"
 
     output=$(docker-php-ext-install "$extension" 2>&1)
     if [ $? -ne 0 ]; then
-        echo "Failed to install PHP extension $extension:"
+        echo "[$(date +"%H:%M:%S")][$extension] Failed to install PHP extension"
         echo "$output"
-        echo "Failed to install $extension"
+        echo "[$(date +"%H:%M:%S")][$extension] Failed to install extension"
         exit
     fi
 
-    echo "[ OK ] PHP extension $extension installed"
+    echo "[$(date +"%H:%M:%S")][$extension] PHP extension $extension installed"
 }
-
-export DEBIAN_FRONTEND=noninteractive
-
-apt-get update
-
-apt-get install -y ${PACKAGES} ${PACKAGES_DEV} ${PACKAGES_COMPRESS} ${PACKAGES_PHP} ${PACKAGES_PHP_VOLATILE}
 
 install_php_extension opcache
 install_php_extension pdo_mysql
@@ -36,5 +25,3 @@ install_php_extension exif
 install_php_extension gd
 install_php_extension intl
 install_php_extension @composer
-
-rm -rf /var/lib/apt/lists/*

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -6,7 +6,7 @@ install_php_extension() {
 
     echo "[$(date +"%H:%M:%S")][$extension] Installing PHP extension"
 
-    output=$(docker-php-ext-install "$extension" 2>&1)
+    output=$(install-php-extensions "$extension" 2>&1)
     if [ $? -ne 0 ]; then
         echo "[$(date +"%H:%M:%S")][$extension] Failed to install PHP extension"
         echo "$output"

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -11,17 +11,12 @@ install_php_extension() {
         echo "[$(date +"%H:%M:%S")][$extension] Failed to install PHP extension"
         echo "$output"
         echo "[$(date +"%H:%M:%S")][$extension] Failed to install extension"
-        exit
+        exit 1
     fi
 
     echo "[$(date +"%H:%M:%S")][$extension] PHP extension $extension installed"
 }
 
-install_php_extension opcache
-install_php_extension pdo_mysql
-install_php_extension zip
-install_php_extension bcmath
-install_php_extension exif
-install_php_extension gd
-install_php_extension intl
-install_php_extension @composer
+for extension in "$@"; do
+    install_php_extension "$extension"
+done


### PR DESCRIPTION
## Don't install dev tools

`wget git curl sudo vim nodejs` are needed only for dev or at build time.
Opened a PR to move them to the dev image: https://github.com/biblioverse/biblioteca/pull/376

## Remove other not needed packages

- `supervisor`, `cron`: apparently unused
- `build-essential`: already comes with the php image

## Extension installer script

Added a script that shows the output of extension installation only if it fails as debugging is made difficult by the huge amount of logs generated

## ARM architecture

Makes the build faster by a few minutes (hard to say as long as the bug is not fixed)

## Bugfix for INTL extension

Apparently the issue comes from the order in which the extensions are built. moving intl and gd to the top fixes the issue

Fixes #18 
